### PR TITLE
Fixed and added missing header of ael2005_conf.c file and a comment on top of ael2005.h

### DIFF
--- a/ael2005_conf.h
+++ b/ael2005_conf.h
@@ -1,3 +1,4 @@
+/* Magic registers */
 #ifndef _AEL2005_SIMPLE_CONF_H
 #define _AEL2005_SIMPLE_CONF_H
 


### PR DESCRIPTION
Added missing header of `ael2005_conf.c` file and a comment on top of `ael2005_conf.h` file.

Physical interfaces are mapped to nf0, nf1, nf2 and nf3 interfaces in
the host through its corresponding Port Address (PRTAD). PRTAD of each
interface is hard-wired on the board so four variables of type `bool`
are added to document and make clear which physical interface is being
configured with a given PRTAD.

`timeout` variable is set to zero for every loop, otherwise it expires
when all the four ports are configured (and the driver fails to load).

Fixed comments on the code to match the general coding style and changed
two messages written by pr_info()

To test it: remove the power of the board so PHYs get unconfigured.
Boot the machine, load the driver and run a network application, e.g.
iperf.
